### PR TITLE
Fix toolbar in popup.php

### DIFF
--- a/inc/toolbar.php
+++ b/inc/toolbar.php
@@ -267,8 +267,8 @@ function toolbar_signature(){
     $sig = $conf['signature'];
     $sig = dformat(null,$sig);
     $sig = str_replace('@USER@',$INPUT->server->str('REMOTE_USER'),$sig);
-    $sig = str_replace('@NAME@',$INFO['userinfo']['name'],$sig);
-    $sig = str_replace('@MAIL@',$INFO['userinfo']['mail'],$sig);
+    $sig = str_replace('@NAME@',is_null($INFO) ? "" : $INFO['userinfo']['name'],$sig);
+    $sig = str_replace('@MAIL@',is_null($INFO) ? "" : $INFO['userinfo']['mail'],$sig);
     $sig = str_replace('@DATE@',dformat(),$sig);
     $sig = str_replace('\\\\n','\\n',$sig);
     return json_encode($sig);


### PR DESCRIPTION
The popup.php throws two warnings because $INFO is NULL within the popup itself.

This fixes this warning but not sure if it is intended to be null. Fixes:
Warning: Trying to access array offset on value of type null in D:\xampp\htdocs\dokuwiki\inc\toolbar.php on line 271
Warning: Trying to access array offset on value of type null in D:\xampp\htdocs\dokuwiki\inc\toolbar.php on line 272